### PR TITLE
Clean docs and add local usage

### DIFF
--- a/Evaluation/HumanEval/README.md
+++ b/Evaluation/HumanEval/README.md
@@ -21,7 +21,7 @@ We've created a sample script, **eval.sh**, that demonstrates how to test the **
 Additionally, for various programming languages, the execution path may differ. Please ensure you update the appropriate paths in the **humaneval/execution.py** file accordingly.
 
 ```bash
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+MODEL_NAME_OR_PATH="/path/to/model"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --language ${LANGUAGE} --dataroot ${DATASET_ROOT} 
@@ -34,41 +34,9 @@ OUPUT_DIR="output"
 MODEL="d2c-33b-instruct"
 
 CUDA_VISIBLE_DEVICES=0,1 python eval_instruct.py \
-    --model "deepseek-ai/$MODEL" \
+    --model "$MODEL" \
     --output_path "$OUPUT_DIR/${LANG}.$MODEL.jsonl" \
     --language $LANG \
     --temp_dir $OUPUT_DIR
 ```
-
-## 4. Experimental Results
-
-We report experimental results here for 8 main-stream programming languages, **python**, **c++**, **java**, **PHP**, **TypeScript**, **C#**, **Bash**, and **JavaScript**. For all open-source models, we utilize this repository to obtain the performance of the models on the HumanEval dataset. We set the maximum input length to **4096** and the maximum output length to **500**, and employ the **greedy search strategy**.
-
-
-#### (1) Multilingual Base Models
-
-| Model             | Size | Python | C++   | Java | PHP  | TS   | C#   | Bash | JS   | Avg  |
-|-------------------|------|--------|-------|------|------|------|------|------|------|------|
-| code-cushman-001  | 12B  | 33.5%  | 31.9% | 30.6%| 28.9%| 31.3%| 22.1%| 11.7%| -    | -    |
-| CodeShell         | 7B   | 35.4%  | 32.9% | 34.2%| 31.7%| 30.2%| 38.0%| 7.0% | 33.5%| 30.4%|
-| CodeGeeX2         | 6B   | 36.0%  | 29.2% | 25.9%| 23.6%| 20.8%| 29.7%| 6.3% | 24.8%| 24.5%|
-| StarCoderBase     | 16B  | 31.7%  | 31.1% | 28.5%| 25.4%| 34.0%| 34.8%| 8.9% | 29.8%| 28.0%|
-| CodeLLama         | 7B   | 31.7%  | 29.8% | 34.2%| 23.6%| 36.5%| 36.7%| 12.0%| 29.2%| 29.2%|
-| CodeLLama         | 13B  | 36.0%  | 37.9% | 38.0%| 34.2%| 45.2%| 43.0%| 16.5%| 32.3%| 35.4%|
-| CodeLLama         | 34B  | 48.2%  | 44.7% | 44.9%| 41.0%| 42.1%| 48.7%| 15.8%| 42.2%| 41.0%|
-| | | | |  |  |  |  |  |  | |
-| D2C-Base| 1.3B   | 34.8%  | 31.1% | 32.3%| 24.2%| 28.9%| 36.7%| 10.1%| 28.6%| 28.3%|
-| D2C-Base| 5.7B   | 48.7%  | 45.3% | 41.1%| 39.7%| 44.7%| 41.1%| 27.8%| 42.2%| 41.3%|
-| D2C-Base| 6.7B   | 49.4%  | 50.3% | 43.0%| 38.5%| 49.7%| 50.0%| 28.5%| 48.4%| 44.7%|
-| D2C-Base|33B  | **56.1%**  | **58.4%** | **51.9%**| **44.1%**| **52.8%**| **51.3%**| **32.3%**| **55.3%**| **50.3%**|
-
-#### (2) Instruction-Tuned Models
-| Model               | Size | Python | C++   | Java | PHP  | TS   | C#   | Bash | JS   | Avg  |
-|---------------------|------|--------|-------|------|------|------|------|------|------|------|
-| GPT-3.5-Turbo         | -    | 76.2%  | 63.4% | 69.2%| 60.9%| 69.1%| 70.8%| 42.4%| 67.1%| 64.9%|
-| GPT-4               | -    | **84.1%**  | **76.4%** | **81.6%**| **77.2%**| **77.4%**| **79.1%**| **58.2%**| **78.0%**| **76.5%**|
-| | | | |  |  |  |  |  |  | |
-| D2C-Instruct | 1.3B  | 65.2%      | 45.3%    | 51.9%    | 45.3%    | 59.7%   |55.1%    | 12.7%    | 52.2%    | 48.4%    |
-| D2C-Instruct | 6.7B  | 78.9%  | 63.4% | 68.4% | 68.9%| 67.2%| 72.8%| 36.7%| 72.7%| 66.1%|
-| D2C-Instruct | 33B | **79.3%**  | **68.9%** | **73.4%** | **72.7%**| **67.9%**| **74.1%**| **43.0%**| **73.9%**| **69.2%**|
 

--- a/Evaluation/HumanEval/eval.sh
+++ b/Evaluation/HumanEval/eval.sh
@@ -1,4 +1,4 @@
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+MODEL_NAME_OR_PATH="/path/to/model"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 CUDA_VISIBLE_DEVICES=1,2,3 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --language ${LANGUAGE} --dataroot ${DATASET_ROOT}

--- a/Evaluation/LeetCode/readme.md
+++ b/Evaluation/LeetCode/readme.md
@@ -10,7 +10,7 @@ Please follow the following two steps to evaluate the model's performance on our
 cd Evaluation/LeetCode
 
 # Set the model or path here
-MODEL="deepseek-ai/d2c-7b-instruct"
+MODEL="/path/to/model"
 
 python vllm_inference.py --model_name_or_path $MODEL --saved_path output/20240121-Jul.d2c-7b-instruct.jsonl
 ```
@@ -24,25 +24,4 @@ python vllm_inference.py --model_name_or_path $MODEL --saved_path output/2024012
 ```bash
 python evaluate_leetcode.py --generation_path output/20240121-Jul.d2c-7b-instruct.jsonl --result_path output/20240121-Jul.d2c-7b-instruct.result.jsonl
 ```
-
-## 3. Experimental Results
-We report experimental results here:
-
-| Model                       | Size | Easy (45) | Medium (91) | Hard (44) | Overall(180) |
-|-----------------------------|------|-----------|-------------|-----------|--------------|
-| WizardCoder-V1.0            | 15B  | 17.8%     | 1.1%        | 0.0%      | 5.0%         |
-| CodeLlama-Instruct          | 34B  | 24.4%     | 4.4%        | 4.5%      | 9.4%         |
-| Phind-CodeLlama-V2          | 34B  | 26.7%     | 8.8%        | 9.1%      | 13.3%        |
-| | | | |
-| GPT-3.5-Turbo               | -    | 46.7%     | 15.4 %      | 15.9%     | 23.3%        |
-| GPT-3.5-Turbo + CoT         | -    | 42.2%     | 15.4%       | 20.5%     | 23.3%        |
-| GPT-4-Turbo                 | -    | 73.3%     | 31.9%       | 25.0%     | 40.6%        |
-| GPT-4-Turbo + CoT           | -    | 71.1%     | 35.2%       | 25.0%     | 41.8%        |
-| | | | |
-| D2C-Instruct     | 1.3B | 22.2%     | 1.1%        | 4.5%      | 7.2%         |
-| D2C-Instruct + CoT | 1.3B | 22.2%   | 2.2%        | 2.3%      | 7.2%         |
-| D2C-Instruct     | 6.7B | 44.4%     | 12.1%       | 9.1%      | 19.4%        |
-| D2C-Instruct + CoT | 6.7B | 44.4%   | 17.6%       | 4.5%      | 21.1%        |
-| D2C-Instruct     | 33B  | 57.8%     | 22.0%       | 9.1%      | 27.8%        |
-| D2C-Instruct + CoT | 33B | 53.3%    | 25.3%       | 11.4%     | 28.9%        |
 

--- a/Evaluation/LeetCode/vllm_inference.py
+++ b/Evaluation/LeetCode/vllm_inference.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--data_path', type=str, default=Path(__file__).parent.joinpath(f"data/{version}.jsonl").as_posix())
-    parser.add_argument('--model_name_or_path', type=str, default='deepseek-ai/d2c-7b-instruct')
+    parser.add_argument('--model_name_or_path', type=str, default='/path/to/model')
     parser.add_argument('--saved_path', type=str, default=f'output/{version}.d2c-7b-instruct.jsonl')
     parser.add_argument('--cot', action='store_true', default=False)
     args = parser.parse_args()

--- a/Evaluation/MBPP/README.md
+++ b/Evaluation/MBPP/README.md
@@ -20,42 +20,9 @@ pip install pytorch
 We've created a sample script, **eval.sh**, that demonstrates how to test the **d2c-1.3b-base** model on the MBPP dataset leveraging **8** GPUs.
 
 ```bash
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+MODEL_NAME_OR_PATH="/path/to/model"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --dataroot ${DATASET_ROOT} 
 ```
-
-## 4. Experimental Results
-
-We report experimental results here for several models. We set the maximum input length to **4096** and the maximum output length to **500**, and employ the **greedy search strategy**.
-
-
-
-#### (1) Multilingual Base Models
-
-| Model             | Size | Pass@1 | 
-|-------------------|------|--------|
-| CodeShell         | 7B   | 38.6%  | 
-| CodeGeeX2         | 6B   | 36.2%  |
-| StarCoder     | 16B  | 42.8%  | 
-| CodeLLama-Base   | 7B   | 38.6%  | 
-| CodeLLama-Base    | 13B  | 47.0%  | 
-| CodeLLama-Base    | 34B  | 55.0%  | 
-| | | | |  |  |  |  |  |  | |
-| D2C-Base| 1.3B   | 46.8%  |
-| D2C-Base| 5.7B   | 57.2%  | 
-| D2C-Base| 6.7B   | 60.6%  | 
-| D2C-Base|33B  | **66.0%**  |
-
-#### (2) Instruction-Tuned Models
-| Model               | Size | Pass@1  |
-|---------------------|------|--------|
-| GPT-3.5-Turbo            | -    | 70.8%  | 
-| GPT-4               | -    | **80.0%**  |
-| | | | |  |  |  |  |  |  | |
-| D2C-Instruct | 1.3B  | 49.4%      |
-| D2C-Instruct  | 6.7B  | 65.4%     |
-| D2C-Instruct  | 33B | **70.0%**     | 
-
 

--- a/Evaluation/MBPP/eval.sh
+++ b/Evaluation/MBPP/eval.sh
@@ -1,4 +1,4 @@
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+MODEL_NAME_OR_PATH="/path/to/model"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 CUDA_VISIBLE_DEVICES=1,2,3 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --language ${LANGUAGE} --dataroot ${DATASET_ROOT}

--- a/Evaluation/PAL-Math/README.md
+++ b/Evaluation/PAL-Math/README.md
@@ -17,7 +17,7 @@ pip install sympy==1.12 pebble timeout-decorator transformers
 We provide an example of testing the **d2c-1.3b-base** model on the **gsm8k** dataset using **8** GPUs. If you wish to use a different model or dataset, you can modify it as needed.
 
 ```bash
-MODEL_NAME_OR_PATH=deepseek-ai/d2c-1.3b-base
+MODEL_NAME_OR_PATH=/path/to/model
 DATA=gsm8k # 'math' 'gsm8k' 'gsm-hard' 'svamp' 'tabmwp' 'asdiv' 'mawps'
 MODEL_DIR_NAME=${MODEL_NAME_OR_PATH##*/}
 GPU_NUM=8

--- a/Evaluation/PAL-Math/run.py
+++ b/Evaluation/PAL-Math/run.py
@@ -186,7 +186,7 @@ def eval(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--data_name", default="math", type=str)
-    parser.add_argument("--model_name_or_path", default="deepseek-ai/d2c-1.3b-base", type=str)
+    parser.add_argument("--model_name_or_path", default="/path/to/model", type=str)
     parser.add_argument("--batch_size", default=16, type=int)
     parser.add_argument("--max_context_length", default=2048, type=int)
     parser.add_argument("--max_output_length", default=512, type=int)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 <p align="center">
 <img width="1000px" alt="D2C" src="pictures/logo.png">
 </p>
-<p align="center"><a href="https://www.deepseek.com/">[<img src="pictures/home.png" width="20px"> Homepage]</a> | <a href="https://coder.deepseek.com/">[🤖 Chat with D2C]</a> | <a href="#">[🤗 Models Download]</a> | <a href="https://discord.gg/Tc7c45Zzu5">[Discord]</a> | <a href="https://github.com/guoday/assert/blob/main/QR.png?raw=true">[WeChat (微信)]</a></p>
-<p align="center">
-  <a href="#"><b>Paper Link</b>👁️</a>
-</p>
+D2C is an open source project that provides compact GPT-based models and tools for code generation and completion.
 <hr>
 
 
@@ -14,35 +11,17 @@
 
 D2C is composed of a series of code language models, each trained from scratch on 2T tokens, with a composition of 87% code and 13% natural language in both English and Chinese. We provide various sizes of the code model, ranging from 1B to 33B versions. Each model is pre-trained on project-level code corpus by employing a window size of 16K and an extra fill-in-the-blank task, to support project-level code completion and infilling. For coding capabilities, D2C achieves state-of-the-art performance among open-source code models on multiple programming languages and various benchmarks.
 
-<p align="center">
-<img src="pictures/result.png" alt="result" width="70%">
-</p>
 
 - **Massive Training Data**: Trained from scratch on 2T tokens, including 87% code and 13% linguistic data in both English and Chinese languages.
 
 - **Highly Flexible & Scalable**: Offered in model sizes of 1B, 5.7B, 6.7B and 33B, enabling users to choose the setup most suitable for their requirements.
 
-- **Superior Model Performance**: State-of-the-art performance among publicly available code models on HumanEval, MultiPL-E, MBPP, DS-1000, and APPS benchmarks.
 
 - **Advanced Code Completion Capabilities**: A window size of 16K and a fill-in-the-blank task, supporting project-level code completion and infilling tasks.
 
 #### Supported Programming Languages
 `['ada', 'agda', 'alloy', 'antlr', 'applescript', 'assembly', 'augeas', 'awk', 'batchfile', 'bluespec', 'c', 'c-sharp', 'clojure', 'cmake', 'coffeescript', 'common-lisp', 'cpp', 'css', 'cuda', 'dart', 'dockerfile', 'elixir', 'elm', 'emacs-lisp', 'erlang', 'f-sharp', 'fortran', 'glsl', 'go', 'groovy', 'haskell', 'html', 'idris', 'isabelle', 'java', 'java-server-pages', 'javascript', 'json', 'julia', 'jupyter-notebook', 'kotlin', 'lean', 'literate-agda', 'literate-coffeescript', 'literate-haskell', 'lua', 'makefile', 'maple', 'markdown', 'mathematica', 'matlab', 'ocaml', 'pascal', 'perl', 'php', 'powershell', 'prolog', 'protocol-buffer', 'python', 'r', 'racket', 'restructuredtext', 'rmarkdown', 'ruby', 'rust', 'sas', 'scala', 'scheme', 'shell', 'smalltalk', 'solidity', 'sparql', 'sql', 'stan', 'standard-ml', 'stata', 'systemverilog', 'tcl', 'tcsh', 'tex', 'thrift', 'typescript', 'verilog', 'vhdl', 'visual-basic', 'xslt', 'yacc', 'yaml', 'zig']`
 
-### 2. Evaluation Results
-We evaluate D2C on various coding-related benchmarks.
-Only `pass@1` results on HumanEval (Python and Multilingual), MBPP, and DS-1000 are reported here:
-
-<p align="center">
-<img src="pictures/table.png" alt="table" width="70%">
-</p>
-
-
-The result shows that D2C-Base-33B significantly outperforms existing open-source code LLMs. Compared with CodeLlama-34B, it leads by 7.9%, 9.3%, 10.8% and 5.9% respectively on HumanEval Python, HumanEval Multilingual, MBPP and DS-1000.
-Surprisingly, our D2C-Base-7B reaches the performance of CodeLlama-34B.
-The D2C-Instruct-33B model after instruction tuning outperforms GPT35-turbo on HumanEval and achieves comparable results with GPT35-turbo on MBPP.
-
-More evaluation details can be found in the [Detailed Evaluation](#6-detailed-evaluation-results).
 
 
 ### 3. Procedure of Data Creation and Model Training
@@ -81,14 +60,21 @@ Launch the demo after installing its requirements:
 python demo/app.py
 ```
 
+### Minimal Local Generation
+
+Run the tiny model on CPU with:
+```bash
+python src/generate.py --start "Hello" --num_tokens 50
+```
+
 Here are some examples of how to use our model.
 
 #### 1) Code Completion
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
-tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/d2c-6.7b-base", trust_remote_code=True)
-model = AutoModelForCausalLM.from_pretrained("deepseek-ai/d2c-6.7b-base", trust_remote_code=True, torch_dtype=torch.bfloat16).cuda()
+tokenizer = AutoTokenizer.from_pretrained("/path/to/model")
+model = AutoModelForCausalLM.from_pretrained("/path/to/model")
 input_text = "#write a quick sort algorithm"
 inputs = tokenizer(input_text, return_tensors="pt").to(model.device)
 outputs = model.generate(**inputs, max_length=128)
@@ -114,8 +100,8 @@ def quick_sort(arr):
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
-tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/d2c-6.7b-base", trust_remote_code=True)
-model = AutoModelForCausalLM.from_pretrained("deepseek-ai/d2c-6.7b-base", trust_remote_code=True, torch_dtype=torch.bfloat16).cuda()
+tokenizer = AutoTokenizer.from_pretrained("/path/to/model")
+model = AutoModelForCausalLM.from_pretrained("/path/to/model")
 input_text = """<｜fim▁begin｜>def quick_sort(arr):
     if len(arr) <= 1:
         return arr
@@ -141,8 +127,8 @@ This code will output the following result:
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
-tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/d2c-6.7b-instruct", trust_remote_code=True)
-model = AutoModelForCausalLM.from_pretrained("deepseek-ai/d2c-6.7b-instruct", trust_remote_code=True, torch_dtype=torch.bfloat16).cuda()
+tokenizer = AutoTokenizer.from_pretrained("/path/to/model")
+model = AutoModelForCausalLM.from_pretrained("/path/to/model")
 messages=[
     { 'role': 'user', 'content': "write a quick sort algorithm in python."}
 ]
@@ -190,8 +176,8 @@ You are an AI programming assistant, utilizing the D2C model, developed by D2C C
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
-tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/d2c-6.7b-base", trust_remote_code=True)
-model = AutoModelForCausalLM.from_pretrained("deepseek-ai/d2c-6.7b-base", trust_remote_code=True, torch_dtype=torch.bfloat16).cuda()
+tokenizer = AutoTokenizer.from_pretrained("/path/to/model")
+model = AutoModelForCausalLM.from_pretrained("/path/to/model")
 
 input_text = """#utils.py
 import torch
@@ -294,14 +280,14 @@ pip install -r requirements-finetune.txt
 Please follow [Sample Dataset Format](#) to prepare your training data.
 Each line is a json-serialized string with two required fields `instruction` and `output`.
 
-After data preparation, you can use the sample shell script to finetune `deepseek-ai/d2c-6.7b-instruct`. 
+After data preparation, you can use the sample shell script to finetune your model.
 Remember to specify `DATA_PATH`, `OUTPUT_PATH`.
 And please choose appropriate hyper-parameters(e.g., `learning_rate`, `per_device_train_batch_size`) according to your scenario.
 
 ```bash
 DATA_PATH="<your_data_path>"
 OUTPUT_PATH="<your_output_path>"
-MODEL="deepseek-ai/d2c-6.7b-instruct"
+MODEL="/path/to/model"
 
 cd finetune && deepspeed finetune_d2c.py \
     --model_name_or_path $MODEL_PATH \
@@ -326,71 +312,6 @@ cd finetune && deepspeed finetune_d2c.py \
     --bf16 True
 ```
 
-### 6. Detailed Evaluation Results
-
-The reproducible code for the following evaluation results can be found in the [Evaluation](https://github.com/deepseek-ai/d2c/tree/main/Evaluation) directory.
-#### 1) Multilingual HumanEval Benchmark
-![HumanEval](pictures/HumanEval.png)
-
-#### 2) MBPP Benchmark
-<img src="pictures/MBPP.png" alt="MBPP" width="40%">
-
-#### 3) DS-1000 Benchmark
-![DS-1000](pictures/DS-1000.png)
-
-#### 4) Program-Aid Math Reasoning Benchmark
-![Math](pictures/Math.png)
-
-### Inference with vLLM
-
-You can also employ [vLLM](https://github.com/vllm-project/vllm) for high-throughput inference.
-
-**Text Completion**
-
-```python
-from vllm import LLM, SamplingParams
-
-tp_size = 4 # Tensor Parallelism
-sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
-model_name = "deepseek-ai/d2c-6.7b-base"
-llm = LLM(model=model_name, trust_remote_code=True, gpu_memory_utilization=0.9, tensor_parallel_size=tp_size)
-
-prompts = [
-    "If everyone in a country loves one another,",
-    "The research should also focus on the technologies",
-    "To determine if the label is correct, we need to"
-]
-outputs = llm.generate(prompts, sampling_params)
-
-generated_text = [output.outputs[0].text for output in outputs]
-print(generated_text)
-```
-
-**Chat Completion**
-
-```python
-from transformers import AutoTokenizer
-from vllm import LLM, SamplingParams
-
-tp_size = 4 # Tensor Parallelism
-sampling_params = SamplingParams(temperature=0.7, top_p=0.9, max_tokens=100)
-model_name = "deepseek-ai/d2c-6.7b-instruct"
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-llm = LLM(model=model_name, trust_remote_code=True, gpu_memory_utilization=0.9, tensor_parallel_size=tp_size)
-
-messages_list = [
-    [{"role": "user", "content": "Who are you?"}],
-    [{"role": "user", "content": "What can you do?"}],
-    [{"role": "user", "content": "Explain Transformer briefly."}],
-]
-prompts = [tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False) for messages in messages_list]
-
-sampling_params.stop = [tokenizer.eos_token]
-outputs = llm.generate(prompts, sampling_params)
-
-generated_text = [output.outputs[0].text for output in outputs]
-print(generated_text)
-```
 
 ### 7. Q&A
 
@@ -424,4 +345,4 @@ See the [LICENSE-CODE](LICENSE-CODE) and [LICENSE-MODEL](LICENSE-MODEL) for more
 
 ### 11. Contact
 
-If you have any questions, please raise an issue or contact us at [service@deepseek.com](mailto:service@deepseek.com).
+If you have any questions, please open an issue on this repository.

--- a/finetune/README.md
+++ b/finetune/README.md
@@ -11,14 +11,14 @@ pip install -r ../requirements-finetune.txt
 Please follow [Sample Dataset Format](https://huggingface.co/datasets/nickrosh/Evol-Instruct-Code-80k-v1) to prepare your training data.
 Each line is a json-serialized string with two required fields `instruction` and `output`.
 
-After data preparation, you can use the sample shell script to finetune `deepseek-ai/d2c-6.7b-instruct`. 
+After data preparation, you can use the sample shell script to finetune your model.
 Remember to specify `DATA_PATH`, `OUTPUT_PATH`.
 And please choose appropriate hyper-parameters(e.g., `learning_rate`, `per_device_train_batch_size`) according to your scenario.
 
 ```bash
 DATA_PATH="<your_data_path>"
 OUTPUT_PATH="<your_output_path>"
-MODEL_PATH="deepseek-ai/d2c-6.7b-instruct"
+MODEL_PATH="/path/to/model"
 
 deepspeed finetune_d2c.py \
     --model_name_or_path $MODEL_PATH \


### PR DESCRIPTION
## Summary
- introduce D2C in the README with a short description
- drop links to deepseek.com and HuggingFace downloads
- remove benchmark result sections
- document how to run the tiny generator on CPU
- sanitize remaining docs and scripts to use local paths

## Testing
- `git status -s`

------
https://chatgpt.com/codex/tasks/task_e_68896056e3e4832988187088d8453c81