### PR TITLE
Remove DeepSeek references and update docs

### DIFF
--- a/Evaluation/LeetCode/vllm_inference.py
+++ b/Evaluation/LeetCode/vllm_inference.py
@@ -70,8 +70,8 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--data_path', type=str, default=Path(__file__).parent.joinpath(f"data/{version}.jsonl").as_posix())
-    parser.add_argument('--model_name_or_path', type=str, default='deepseek-ai/d2c-7b-instruct')
-    parser.add_argument('--saved_path', type=str, default=f'output/{version}.d2c-7b-instruct.jsonl')
+    parser.add_argument('--model_name_or_path', type=str, default='path/to/local/model')
+    parser.add_argument('--saved_path', type=str, default=f'output/{version}.local.jsonl')
     parser.add_argument('--cot', action='store_true', default=False)
     args = parser.parse_args()
 

--- a/Evaluation/PAL-Math/run.py
+++ b/Evaluation/PAL-Math/run.py
@@ -186,7 +186,7 @@ def eval(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--data_name", default="math", type=str)
-    parser.add_argument("--model_name_or_path", default="deepseek-ai/d2c-1.3b-base", type=str)
+    parser.add_argument("--model_name_or_path", default="path/to/local/model", type=str)
     parser.add_argument("--batch_size", default=16, type=int)
     parser.add_argument("--max_context_length", default=2048, type=int)
     parser.add_argument("--max_output_length", default=512, type=int)


### PR DESCRIPTION
## Summary
- clean README from DeepSeek-specific links and images
- swap HuggingFace examples for local CPU usage
- adjust evaluation scripts to use a local model path

## Testing
- `flake8 || true`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896e0f3f308329afbbbaad7cb94ec6