### PR TITLE
Enable CORS

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,18 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from src.core_infer import generate
 
 app = FastAPI()
+
+# Enable CORS for all origins to allow cross-domain requests
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class GenerateRequest(BaseModel):


### PR DESCRIPTION
## Summary
- enable CORS in the FastAPI app

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_688c4251dc088329a013cd5170e5f064